### PR TITLE
Updated python/pem2plex.py to run on modern python

### DIFF
--- a/python/pem2plex.py
+++ b/python/pem2plex.py
@@ -7,11 +7,11 @@ from OpenSSL.crypto import *
 
 def main():
   if(len(sys.argv) != 4):
-    print sys.argv[0] + " /path/to/ssl.crt /path/to/ssl.key ProcessedMachineIdentifier"
+    print( sys.argv[0] + " /path/to/ssl.crt /path/to/ssl.key ProcessedMachineIdentifier")
     sys.exit(0)
   hash = hashlib.sha512()
-  hash.update('plex')
-  hash.update(sys.argv[3])
+  hash.update('plex'.encode('utf-8'))
+  hash.update(sys.argv[3].encode('utf-8'))
   passphrase = hash.hexdigest()
 
   with open(sys.argv[1], 'rb') as f:
@@ -25,9 +25,9 @@ def main():
   p12 = PKCS12()
   p12.set_certificate(cert)
   p12.set_privatekey(key)
-  open("certificate.p12", 'w' ).write( p12.export(passphrase) )
+  open("certificate.p12", 'wb' ).write( p12.export(passphrase) )
 
-  print passphrase
+  print(passphrase)
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
I saw this on https://hobo.house/2016/11/11/how-to-use-self-signed-ssl-certificates-for-plex-media-server/ . It worked great after the changes below.  Thank you for hosting the script!